### PR TITLE
Update AccountController.class.php

### DIFF
--- a/inc/SP/Controller/AccountController.class.php
+++ b/inc/SP/Controller/AccountController.class.php
@@ -290,9 +290,14 @@ class AccountController extends ControllerBase implements ActionsInterface
             $this->view->assign('publicLinkId', $PublicLinkData ? $PublicLinkData->getPublicLinkId() : 0);
 
             $this->view->assign('accountPassDate', date('Y-m-d H:i:s', $this->AccountData->getAccountPassDate()));
-            $this->view->assign('accountPassDateChange', date('Y-m-d', $this->AccountData->getAccountPassDateChange() ?: 0));
+            if ($this->AccountData->getAccountPassDateChange() == 0) {
+                $this->view->assign('accountPassDateChange', '');
+            } else {
+                $this->view->assign('accountPassDateChange', date('Y-m-d', $this->AccountData->getAccountPassDateChange() ?: 0));
+            }
         } else {
-            $this->view->assign('accountPassDateChange', date('Y-m-d', time() + 7776000));
+            $this->view->assign('accountPassDateChange', ''); //no expiration for default account creation
+            //$this->view->assign('accountPassDateChange', date('Y-m-d', time() + 7776000)); //automatic expiration for default account creation  
         }
 
         $this->view->assign('actionId', $this->getAction());


### PR DESCRIPTION
change 01 --> By default editing an account without expiration date return an error while saving because application automatically set 1970-01-01 as expiration date.

change 02 --> By default creating an account will set an expiration after 7776000. Now you can choose